### PR TITLE
Fix one format bug

### DIFF
--- a/vigoler/test_files/no_formats.json
+++ b/vigoler/test_files/no_formats.json
@@ -1,0 +1,27 @@
+{
+    "webpage_url_basename": "video_id",
+    "playlist": null,
+    "extractor_key": "Openload",
+    "playlist_index": null,
+    "fulltitle": "movie.2018.720p.mp4",
+    "title": "movie.2018.720p.mp4",
+    "_filename": "movie.2018.720p.mp4-video_id.mp4",
+    "format_id": "0",
+    "thumbnail": "https://thumb.oloadcdn.net/splash/video_id/thumb.jpg",
+    "format": "0 - unknown",
+    "url": "https://openload.co/stream/video_id~1548610975~192.168.0.0~u-x4488e?mime=true",
+    "id": "video_id",
+    "webpage_url": "https://openload.co/embed/video_id",
+    "ext": "mp4",
+    "display_id": "video_id",
+    "subtitles": null,
+    "extractor": "Openload",
+    "thumbnails": [
+        {
+            "url": "https://thumb.oloadcdn.net/splash/video_id/thumb.jpg",
+            "id": "0"
+        }
+    ],
+    "requested_subtitles": null,
+    "protocol": "https"
+}

--- a/vigoler/youtubedl_wrapper.go
+++ b/vigoler/youtubedl_wrapper.go
@@ -52,8 +52,18 @@ func (you *YoutubeDlWrapper) UpdateYoutubeDl() {
 		fmt.Println(err)
 	}
 }
+func createSingleFormat(dMap map[string]interface{}) []Format {
+	url := dMap["url"].(string)
+	formatID, _ := dMap["format_id"].(string)
+	ext := dMap["ext"].(string)
+	return []Format{Format{fileSize: -1, url: url, formatID: formatID, Ext: ext, hasVideo: true, hasAudio: true}}
+}
 func readFormats(dMap map[string]interface{}) []Format {
-	listOfFormats := dMap["formats"].([]interface{})
+	mapOfFormats := dMap["formats"]
+	if mapOfFormats == nil {
+		return createSingleFormat(dMap)
+	}
+	listOfFormats := mapOfFormats.([]interface{})
 	formats := make([]Format, 0, len(listOfFormats))
 	for _, format := range listOfFormats {
 		formatMap := format.(map[string]interface{})


### PR DESCRIPTION
Fix a bug when downloading from websites that does not support multiple formats(like openload).
So youtube-dl return json with no formats at all and put the data in the root of the json, so read from root.