### PR TITLE
Fix youtubedl formats order

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,5 @@ matrix:
   allow_failures:
     - os: windows
       go: master
+before_install:
+- git lfs pull

--- a/vigoler/test_files/no_formats.json
+++ b/vigoler/test_files/no_formats.json
@@ -1,35 +1,3 @@
-{
-  "webpage_url_basename": "video_id",
-  "playlist": null,
-  "extractor_key": "Openload",
-  "playlist_index": null,
-  "fulltitle": "fmovie.2018.720p.mp4",
-  "title": "movie.2018.720p.mp4",
-  "_filename": "movie.2018.720p.mp4-video_id.mp4",
-  "format_id": "0",
-  "http_headers": {
-    "Accept-Charset": "Accept-Charset",
-    "User-Agent": "User-Agent",
-    "Cookie": "Cookie",
-    "Accept-Language": "Accept-Language",
-    "Accept-Encoding": "Accept-Encoding",
-    "Accept": "Accept"
-  },
-  "thumbnail": "https://thumb.oloadcdn.net/splash/video_id/thumb.jpg",
-  "format": "0 - unknown",
-  "url": "https://openload.co/stream/video_id~1548610975~192.168.0.0~u-x4488e?mime=true",
-  "id": "video_id",
-  "webpage_url": "https://openload.co/embed/video_id",
-  "ext": "mp4",
-  "display_id": "video_id",
-  "subtitles": null,
-  "extractor": "Openload",
-  "thumbnails": [
-    {
-      "url": "https://thumb.oloadcdn.net/splash/video_id/thumb.jpg",
-      "id": "0"
-    }
-  ],
-  "requested_subtitles": null,
-  "protocol": "https"
-}
+version https://git-lfs.github.com/spec/v1
+oid sha256:78bfc674243a20191ee928f0e920d37fd1b63e1525281ae50ecc6de58bea9efd
+size 1052

--- a/vigoler/test_files/non_order_formats.json
+++ b/vigoler/test_files/non_order_formats.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4ab9d7103769976b9e0a25a079005b5fa9bf868928c2b58138fd71c9b29ab6e9
+size 364851

--- a/vigoler/youtubedl_wrapper.go
+++ b/vigoler/youtubedl_wrapper.go
@@ -23,6 +23,8 @@ type Format struct {
 	hasAudio    bool
 	protocol    string
 	httpHeaders map[string]string
+	height      float64
+	width       float64
 }
 type VideoUrl struct {
 	url          string
@@ -72,13 +74,31 @@ func createSingleFormat(formatMap map[string]interface{}) Format {
 	ext := formatMap["ext"].(string)
 	hasVideo := formatMap["vcodec"] != "none"
 	hasAudio := formatMap["acodec"] != "none"
+	var w, h float64
+	if hasVideo {
+		w = formatMap["width"].(float64)
+		h = formatMap["height"].(float64)
+	} else {
+		w = -1
+		h = -1
+	}
 	protocol := formatMap["protocol"].(string)
 	httpHeaderMap := formatMap["http_headers"].(map[string]interface{})
 	httpHeaders := make(map[string]string)
 	for k, v := range httpHeaderMap {
 		httpHeaders[k] = v.(string)
 	}
-	return Format{fileSize: fileSize, url: url, formatID: formatID, Ext: ext, protocol: protocol, hasVideo: hasVideo, hasAudio: hasAudio, httpHeaders: httpHeaders}
+	return Format{fileSize: fileSize, url: url, formatID: formatID, Ext: ext, protocol: protocol, hasVideo: hasVideo, hasAudio: hasAudio, httpHeaders: httpHeaders, height: h, width: w}
+}
+func sortFormats(formats []Format) {
+	l := len(formats)
+	for i := 0; i < l-1; i++ {
+		if formats[i].width > formats[i+1].width && formats[i].height > formats[i+1].height && formats[i].hasAudio == formats[i+1].hasAudio {
+			tempFormat := formats[i]
+			formats[i] = formats[i+1]
+			formats[i+1] = tempFormat
+		}
+	}
 }
 func readFormats(dMap map[string]interface{}) []Format {
 	mapOfFormats := dMap["formats"]
@@ -90,6 +110,7 @@ func readFormats(dMap map[string]interface{}) []Format {
 	for _, format := range listOfFormats {
 		formats = append(formats, createSingleFormat(format.(map[string]interface{})))
 	}
+	sortFormats(formats)
 	return formats
 }
 func getURLData(output *<-chan string, url string) ([]map[string]interface{}, string, error) {

--- a/vigoler/youtubedl_wrapper.go
+++ b/vigoler/youtubedl_wrapper.go
@@ -40,7 +40,7 @@ type HttpError struct {
 type DownloadStatus func(url VideoUrl, percent, size float32)
 
 func (format Format) String() string {
-	return fmt.Sprintf("id=%s, size=%v, ext=%s, protocol=%s", format.formatID, format.fileSize, format.Ext, format.protocol)
+	return fmt.Sprintf("id=%s, size=%v, height=%v, width=%v, ext=%s, protocol=%s", format.formatID, format.fileSize, format.height, format.width, format.Ext, format.protocol)
 }
 func (e *HttpError) Error() string {
 	return fmt.Sprintf("Http error while requested %s. error message is: %s", e.Video, e.ErrorMessage)
@@ -75,7 +75,7 @@ func createSingleFormat(formatMap map[string]interface{}) Format {
 	hasVideo := formatMap["vcodec"] != "none"
 	hasAudio := formatMap["acodec"] != "none"
 	var w, h float64
-	if hasVideo {
+	if formatMap["width"] != nil {
 		w = formatMap["width"].(float64)
 		h = formatMap["height"].(float64)
 	} else {


### PR DESCRIPTION
Youtube-dl sort the formats of the videos by bit rate, but for videos in youtube without bit rate it is fall back to sorting by tbr.
For some videos of this kind of sorting yield bad result (better video is lower in order). (see https://github.com/ytdl-org/youtube-dl/issues/14143).
To fix this resort the formats from youtube-dl.